### PR TITLE
add-to-globals-annotation defun

### DIFF
--- a/js2r-functions.el
+++ b/js2r-functions.el
@@ -49,4 +49,19 @@
     (forward-list)
     (insert ";")))
 
+(defun js2r--add-to-globals-annotation ()
+  (interactive)
+  (let ((var (word-at-point)))
+    (save-excursion
+      (beginning-of-buffer)
+      (when (not (string-match "^/\\* global " (current-line)))
+          (newline)
+          (previous-line)
+          (insert "/* global */"))
+      (while (not (string-match "*/" (current-line)))
+        (next-line))
+      (end-of-line)
+      (delete-char -2)
+      (insert (concat var " */")))))
+
 (provide 'js2r-functions)


### PR DESCRIPTION
Small function to add the word at point to the globals annotation (see issue #1)
