### PR TITLE
Fixes #37

### DIFF
--- a/features/js2r-extract-var.feature
+++ b/features/js2r-extract-var.feature
@@ -99,7 +99,7 @@ Feature: Extract var
     Then I should see:
     """
     beforeEach(function () {
-      var jkl = 'baz';
-      spyOn(Foo, 'bar').andReturn(jkl);
+        var jkl = 'baz';
+        spyOn(Foo, 'bar').andReturn(jkl);
     });
     """

--- a/js2r-vars.el
+++ b/js2r-vars.el
@@ -238,7 +238,7 @@
   (let ((deactivate-mark nil)
         (expression (buffer-substring beg end))
         (orig-var-end (make-marker))
-        new-var-end
+        (new-var-end (make-marker))
         (name (or (js2r--object-literal-key-behind beg) "name")))
 
     (delete-region beg end)
@@ -247,7 +247,7 @@
 
     (goto-char (js2r--start-of-parent-stmt))
     (insert "var " name)
-    (setq new-var-end (point))
+    (set-marker new-var-end (point))
     (insert " = " expression ";")
     (when (or (js2r--line-above-is-blank)
               (string-match-p "^function " expression))
@@ -260,7 +260,8 @@
       (mc/create-fake-cursor-at-point))
     (goto-char orig-var-end)
     (set-mark (- (point) (length name)))
-    (set-marker orig-var-end nil))
+    (set-marker orig-var-end nil)
+    (set-marker new-var-end nil))
   (mc/maybe-multiple-cursors-mode))
 
 ;; Split var declaration


### PR DESCRIPTION
The issue had to do with indenting and a missing marker, resulting in
the registered position for the new var being shifted when the region is
indented.

When the code is correctly indented before the refactoring, then it all worked fine, explaining why @magnars could not reproduce it.
