### PR TITLE
Fix move-line-up function

### DIFF
--- a/js2r-conveniences.el
+++ b/js2r-conveniences.el
@@ -82,11 +82,8 @@ split, join it instead."
 
 (defun move-line-up ()
   (interactive)
-  (let ((col (current-column)))
-    (save-excursion
-      (forward-line)
-      (transpose-lines -1))
-    (move-to-column col)))
+  (transpose-lines 1)
+  (forward-line -2))
 
 (defun js2r--current-line-is-prefixed-with-list-item-start ()
   (save-excursion


### PR DESCRIPTION
I noticed js2r-move-line-up did not work correctly, so I found this implementation in EmacsWiki (cached) and it works like a charm.
