### PR TITLE
Fix project name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To fetch the test dependencies, install
 [cask](https://github.com/rejeep/cask.el) if you haven't already,
 then:
 
-    $ cd /path/to/expand-region
+    $ cd /path/to/js2-refactor.el
     $ cask
 
 Run the tests with:


### PR DESCRIPTION
This makes a change to the "Contribute" section of the readme to have the right name for the current project.