### PR TITLE
Implement let & const for js2r-inline-var

### DIFF
--- a/features/js2r-inline-var.feature
+++ b/features/js2r-inline-var.feature
@@ -27,3 +27,77 @@ Feature: Extract var
     	baz(bar());
     }
     """
+
+  Scenario: Inlining let with tab indentation
+    Given I insert:
+    """
+    function hello() {
+    	let foo = bar();
+    	baz(foo);
+    }
+    """
+    And I turn on js2-mode
+    And I go to the front of the word "foo"
+    And I press "C-c C-m iv"
+    Then I should see:
+    """
+    function hello() {
+    	baz(bar());
+    }
+    """
+
+  Scenario: Inlining const with tab indentation
+    Given I insert:
+    """
+    function hello() {
+    	const foo = bar();
+    	baz(foo);
+    }
+    """
+    And I turn on js2-mode
+    And I go to the front of the word "foo"
+    And I press "C-c C-m iv"
+    Then I should see:
+    """
+    function hello() {
+    	baz(bar());
+    }
+    """
+
+  Scenario: Inlining let, multiple statements
+    Given I insert:
+    """
+    function hello() {
+    	let foo = bar(), qux = 13;
+    	baz(foo);
+    }
+    """
+    And I turn on js2-mode
+    And I go to the front of the word "foo"
+    And I press "C-c C-m iv"
+    Then I should see:
+    """
+    function hello() {
+    	let qux = 13;
+    	baz(bar());
+    }
+    """
+
+  Scenario: Inlining const, multiple statements
+    Given I insert:
+    """
+    function hello() {
+    	const foo = bar(), qux = 13;
+    	baz(foo);
+    }
+    """
+    And I turn on js2-mode
+    And I go to the front of the word "foo"
+    And I press "C-c C-m iv"
+    Then I should see:
+    """
+    function hello() {
+    	const qux = 13;
+    	baz(bar());
+    }
+    """

--- a/js2r-vars.el
+++ b/js2r-vars.el
@@ -186,10 +186,14 @@
 
 (defun js2r--was-single-var ()
   (or (string= "var ;" (current-line-contents))
+      (string= "const ;" (current-line-contents))
+      (string= "let ;" (current-line-contents))
       (string= "," (current-line-contents))))
 
 (defun js2r--was-starting-var ()
-  (looking-back "var "))
+  (or (looking-back "var ")
+      (looking-back "const ")
+      (looking-back "let ")))
 
 (defun js2r--was-ending-var ()
   (looking-at ";"))


### PR DESCRIPTION
[fixes #49]

This adds support for `let` and `const` to `js2r-inline-var`