### PR TITLE
Don't use yasnippet obsoleted variables/functions

### DIFF
--- a/js2r-functions.el
+++ b/js2r-functions.el
@@ -262,7 +262,7 @@
                             (js2-name-node-name it)
                           "key"))
                 args)))
-    (yas/expand-snippet (js2r--create-object-with-arguments names args)
+    (yas-expand-snippet (js2r--create-object-with-arguments names args)
                         (point)
                         (save-excursion (forward-list) (point)))))
 

--- a/js2r-wrapping.el
+++ b/js2r-wrapping.el
@@ -40,8 +40,8 @@
   (js2r--skip-region-whitespace)
   (setq beg (min (point) (mark)))
   (setq end (max (point) (mark)))
-  (let ((yas/wrap-around-region t))
-    (yas/expand-snippet "for (var i = 0, l = ${1:length}; i < l; i++) {\n$0\n}"
+  (let ((yas-wrap-around-region t))
+    (yas-expand-snippet "for (var i = 0, l = ${1:length}; i < l; i++) {\n$0\n}"
                         beg end)))
 
 (provide 'js2r-wrapping)


### PR DESCRIPTION
This fixes following byte-compile warnings. This package requires yasnippet 0.9.0.1 or higher versions, so there is no problem for older yasnippet users.

```
js2r-functions.el:265:61:Warning: `yas/expand-snippet' is an obsolete function     
    (as of yasnippet 0.8); use `yas-expand-snippet' instead.

js2r-wrapping.el:43:10:Warning: `yas/wrap-around-region' is an obsolete            
    variable (as of yasnippet 0.8); use `yas-wrap-around-region' instead.          
js2r-wrapping.el:43:10:Warning: `yas/expand-snippet' is an obsolete function       
    (as of yasnippet 0.8); use `yas-expand-snippet' instead.
```