### PR TITLE
Allow for optional space in global

### DIFF
--- a/js2r-vars.el
+++ b/js2r-vars.el
@@ -98,10 +98,10 @@
   (let ((var (thing-at-point 'symbol)))
     (save-excursion
       (beginning-of-buffer)
-      (when (not (string-match "^/\\* global " (current-line-contents)))
+      (when (not (string-match "^/\\* *global " (current-line-contents)))
         (newline)
         (forward-line -1)
-        (insert "/* global */")
+        (insert "/*global */")
         (newline)
         (forward-line -1))
       (while (not (string-match "*/" (current-line-contents)))


### PR DESCRIPTION
This should make the global definition work irrespective of leading spaces.

However, it always defaults to inserting the traditional `/*global foobar */`, with no space.