### PR TITLE
Fix rename-var to not rename shadowed variables

### DIFF
--- a/features/js2r-rename-var.feature
+++ b/features/js2r-rename-var.feature
@@ -48,3 +48,13 @@ Feature: Rename variable
     And I press "C-c C-m rv"
     And I type "ghi"
     Then I should see "var ghi = this.abc;"
+
+  Scenario: Don't rename shadowed variables
+    Given delete-selection-mode is active
+    When I insert "var abc; abc=1; function shadow(abc) { abc=2; } function noShadow() { abc=3; }"
+    And I turn on js2-mode and js2-refactor-mode
+    And I go to the end of the word "var"
+    And I press "C-f"
+    And I press "C-c C-m rv"
+    And I type "ghi"
+    Then I should see "var ghi; ghi=1; function shadow(abc) { abc=2; } function noShadow() { ghi=3; }"


### PR DESCRIPTION
Fixes #77

Previously js2r--local-usages-of-name-node checked all nodes under the renamed variables defining scope and renamed all name nodes that had the same name as the one we `rename-var`'d on. I added an additional check that renamed nodes must also share the same defining scope as the one we renamed on, to avoid renaming variables that are redeclared in nested scopes.

I added a small helper function in js2r-vars.el, `js2r--name-node-defining-scope`, to get the defining scope of a name node without needing the two steps of looking up the enclosing scope and then the defining scope.

There's a new test case in js2r-rename-var.feature that covers the new behaviour. It fails without this change and passes with it, as expected.

I'm happy to make changes to fix any problems or fit the project better, please let me know if there's anything blocking this being merged. Thanks!