### PR TITLE
Customize preferred quotes

### DIFF
--- a/js2-refactor.el
+++ b/js2-refactor.el
@@ -142,8 +142,16 @@
 
 ;;; Settings ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defvar js2r-use-strict nil
-  "When non-nil, js2r inserts strict declarations in IIFEs.")
+(defgroup js2-refactor nil
+  "Minor mode providing JavaScript refactorings."
+  :group 'tools
+  :prefix "js2r-"
+  :link '(url-link :tag "Repository" "https://github.com/magnars/js2-refactor.el"))
+
+(defcustom js2r-use-strict nil
+  "When non-nil, js2r inserts strict declarations in IIFEs."
+  :group 'js2-refactor
+  :type 'boolean)
 
 ;;; Keybindings ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/js2-refactor.el
+++ b/js2-refactor.el
@@ -153,6 +153,12 @@
   :group 'js2-refactor
   :type 'boolean)
 
+(defcustom js2r-prefered-quote-type 1
+  "The prefered quote style for strings."
+  :group 'js2-refactor
+  :type '(choice (const :tag "Double" 1)
+                 (const :tag "Single" 2)))
+
 ;;; Keybindings ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun js2r--add-keybindings (key-fn)

--- a/js2r-conveniences.el
+++ b/js2r-conveniences.el
@@ -42,7 +42,7 @@
       (when (looking-at "[;{]")
         (forward-char 1))
       (newline-and-indent)
-      (insert "console.log(\"" stmt " = \", " stmt ");"))))
+      (insert "console.log(" (js2r--wrap-text stmt " = ") ", " stmt ");"))))
 
 (defun js2r-debug-this ()
   "Debug the node at point, adding a 'debug()' statement."
@@ -56,7 +56,7 @@
       (when (looking-at "[;{]")
         (forward-char 1))
       (newline-and-indent)
-      (insert "debug(\"" stmt " = %s\", " stmt ");"))))
+      (insert "debug(" (js2r--wrap-text stmt " = %s") ", " stmt ");"))))
 
 (defun js2r--figure-out-what-to-log-where ()
   "Return a dotted pair containing the statement to log and the

--- a/js2r-helpers.el
+++ b/js2r-helpers.el
@@ -25,6 +25,15 @@
 (require 'dash)
 (require 's)
 
+(defun js2r--wrap-text-with-prefered-quotes (&rest text)
+  "Wrap TEXT with the prefered quotes.  The prefered quotes is set with `js2r-prefered-quote-type'."
+  (let ((prefered-quotes "\""))
+    (when (= 2 js2r-prefered-quote-type)
+      (setq prefered-quotes "'"))
+    (concat prefered-quotes (apply 'concat text) prefered-quotes)))
+
+(defalias 'js2r--wrap-text 'js2r--wrap-text-with-prefered-quotes)
+
 (defun js2r--fix-special-modifier-combinations (key)
   (case key
     ("C-s-i" "s-TAB")

--- a/js2r-helpers.el
+++ b/js2r-helpers.el
@@ -25,14 +25,12 @@
 (require 'dash)
 (require 's)
 
-(defun js2r--wrap-text-with-prefered-quotes (&rest text)
+(defun js2r--wrap-text (&rest text)
   "Wrap TEXT with the prefered quotes.  The prefered quotes is set with `js2r-prefered-quote-type'."
   (let ((prefered-quotes "\""))
     (when (= 2 js2r-prefered-quote-type)
       (setq prefered-quotes "'"))
     (concat prefered-quotes (apply 'concat text) prefered-quotes)))
-
-(defalias 'js2r--wrap-text 'js2r--wrap-text-with-prefered-quotes)
 
 (defun js2r--fix-special-modifier-combinations (key)
   (case key


### PR DESCRIPTION
Using the _log this_ is a nice functionality. However, the only quote style supported is using double quotes (`"`). This can be quite bothering if someone uses a linter that forbids the use of quotes style.

Those patches fix this problem