### PR TITLE
Fix false negatives returned by js2r--local-name-node-p

### DIFF
--- a/features/js2r-rename-var.feature
+++ b/features/js2r-rename-var.feature
@@ -19,6 +19,31 @@ Feature: Rename variable
     And I type "ghi"
     Then I should see "var ghi = 123, def = ghi;"
 
+  Scenario: Rename not confused by comments
+    Given delete-selection-mode is active
+    When I insert:
+    """
+    function foo(){}
+    var x = {
+        foo/**/: 1
+    };
+    // comment ends in dot.
+    foo();
+    """
+    And I turn on js2-mode and js2-refactor-mode
+    And I go to the front of the word "foo"
+    And I press "C-c C-m rv"
+    And I type "bar"
+    Then I should see:
+    """
+    function bar(){}
+    var x = {
+        foo/**/: 1
+    };
+    // comment ends in dot.
+    bar();
+    """
+
   Scenario: Rename function params
     Given delete-selection-mode is active
     When I insert "function test(abc) { alert(abc); }"

--- a/js2r-vars.el
+++ b/js2r-vars.el
@@ -44,13 +44,12 @@
     current-node))
 
 (defun js2r--local-name-node-p (node)
-  (and (js2-name-node-p node)
-       (not (save-excursion ; not key in object literal { key: value }
-              (goto-char (+ (js2-node-abs-pos node) (js2-node-len node)))
-              (looking-at "[\n\t ]*:")))
-       (not (save-excursion ; not property lookup on object
-              (goto-char (js2-node-abs-pos node))
-              (looking-back "\\.[\n\t ]*")))))
+  (let ((parent (js2-node-parent node)))
+    (and parent (js2-name-node-p node)
+         (not (and (js2-object-prop-node-p parent)
+                   (eq node (js2-object-prop-node-left parent))))
+         (not (and (js2-prop-get-node-p parent)
+                   (eq node (js2-prop-get-node-right parent)))))))
 
 (defun js2r--name-node-defining-scope (name-node)
   (unless (js2r--local-name-node-p name-node)

--- a/js2r-vars.el
+++ b/js2r-vars.el
@@ -64,8 +64,6 @@
     (error "Node is not on a local identifier"))
   (let* ((name (js2-name-node-name name-node))
          (scope (js2r--name-node-defining-scope name-node))
-         (current-start (js2-node-abs-pos name-node))
-         (current-end (+ current-start (js2-node-len name-node)))
          (result nil))
     (js2-visit-ast
      scope


### PR DESCRIPTION
Regexp-based checks can easily be fooled by comments, for example:

```
// This does something.
localFunction(something);
```

Previously, `js2r--local-name-node-p` would return nil for `localFunction` here, because it follows a dot.  In consequence, this case would be missed by a rename-var operation.

Switched to use the actual AST info (it's much faster, too).
