### PR TITLE
Extend js2r-log-this

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ to pick and choose your own keybindings with a smattering of:
  * `sv` is `split-var-declaration`: Splits a `var` with multiple vars declared, into several `var` statements.
  * `ss` is `split-string`: Splits a `string`.
  * `uw` is `unwrap`: Replaces the parent statement with the selected region.
- * `lt` is `log-this`: Adds a console.log() statement for what is at point (or region).
+ * `lt` is `log-this`: Adds a console.log() statement for what is at point (or region). With a prefix argument, use JSON pretty-printing.
  * `dt` is `debug-this`: Adds a debug() statement for what is at point (or region).
  * `sl` is `forward-slurp`: Moves the next statement into current function, if-statement, for-loop or while-loop.
  * `ba` is `forward-barf`: Moves the last child out of current function, if-statement, for-loop or while-loop.

--- a/js2r-conveniences.el
+++ b/js2r-conveniences.el
@@ -30,9 +30,9 @@
 
 (require 'js2r-helpers)
 
-(defun js2r-log-this ()
+(defun js2r-log-this (prefix)
   "Log of the node at point, adding a 'console.log()' statement."
-  (interactive)
+  (interactive "P")
   (js2r--guard)
   (let* ((log-info (js2r--figure-out-what-to-log-where))
          (stmt (car log-info))
@@ -42,7 +42,9 @@
       (when (looking-at "[;{]")
         (forward-char 1))
       (newline-and-indent)
-      (insert "console.log(" (js2r--wrap-text stmt " = ") ", " stmt ");"))))
+      (if prefix
+          (insert "console.log(\"" stmt " = \", JSON.stringify(" stmt ", null, 2));")
+        (insert "console.log(\"" stmt " = \", " stmt ");")))))
 
 (defun js2r-debug-this ()
   "Debug the node at point, adding a 'debug()' statement."

--- a/js2r-conveniences.el
+++ b/js2r-conveniences.el
@@ -31,7 +31,7 @@
 (require 'js2r-helpers)
 
 (defun js2r-log-this (arg)
-  "Log of the node at point, adding a 'console.log()' statement. With a prefix argument ARG, use JSON pretty-printing for logging."
+  "Log of the node at point, adding a 'console.log()' statement.  With a prefix argument ARG, use JSON pretty-printing for logging."
   (interactive "P")
   (js2r--guard)
   (let* ((log-info (js2r--figure-out-what-to-log-where))
@@ -43,7 +43,9 @@
         (forward-char 1))
       (newline-and-indent)
       (if arg
-          (insert "console.log(\"" stmt " = \", JSON.stringify(" stmt ", null, 2));")
+          (progn (insert "console.log(\"" stmt " = \");")
+                 (newline-and-indent)
+                 (insert "console.dir(" stmt ", { depth:null, colors: true });"))
         (insert "console.log(\"" stmt " = \", " stmt ");")))))
 
 (defun js2r-debug-this ()

--- a/js2r-conveniences.el
+++ b/js2r-conveniences.el
@@ -30,7 +30,7 @@
 
 (require 'js2r-helpers)
 
-(defun js2r-log-this (prefix)
+(defun js2r-log-this (arg)
   "Log of the node at point, adding a 'console.log()' statement."
   (interactive "P")
   (js2r--guard)
@@ -42,7 +42,7 @@
       (when (looking-at "[;{]")
         (forward-char 1))
       (newline-and-indent)
-      (if prefix
+      (if arg
           (insert "console.log(\"" stmt " = \", JSON.stringify(" stmt ", null, 2));")
         (insert "console.log(\"" stmt " = \", " stmt ");")))))
 

--- a/js2r-conveniences.el
+++ b/js2r-conveniences.el
@@ -31,7 +31,8 @@
 (require 'js2r-helpers)
 
 (defun js2r-log-this (arg)
-  "Log of the node at point, adding a 'console.log()' statement.  With a prefix argument ARG, use JSON pretty-printing for logging."
+  "Log of the node at point, adding a 'console.log()' statement.
+With a prefix argument ARG, use JSON pretty-printing for logging."
   (interactive "P")
   (js2r--guard)
   (let* ((log-info (js2r--figure-out-what-to-log-where))

--- a/js2r-conveniences.el
+++ b/js2r-conveniences.el
@@ -31,7 +31,7 @@
 (require 'js2r-helpers)
 
 (defun js2r-log-this (arg)
-  "Log of the node at point, adding a 'console.log()' statement."
+  "Log of the node at point, adding a 'console.log()' statement. With a prefix argument ARG, use JSON pretty-printing for logging."
   (interactive "P")
   (js2r--guard)
   (let* ((log-info (js2r--figure-out-what-to-log-where))


### PR DESCRIPTION
If user add a prefix argument (`C-u`) for `js2r-log-this`, then generate an
`console.log` with the variable inside a `JSON.stringify`. Example: 

```javascript
console.log("orderRef = ", JSON.stringify(orderRef, null, 2));
```

This logs a JSON object pretty printed. Its very useful for me at least.