### PR TITLE
Log location improvements

### DIFF
--- a/features/js2r-log-this.feature
+++ b/features/js2r-log-this.feature
@@ -104,3 +104,24 @@ Feature: Log this
     function a() { callFunc(arg);
                    console.log("abc = ", abc);return abc; }
     """
+
+  Scenario: Console.log before point
+    Given I insert:
+    """
+    function abc() {
+        callFunc(arg);
+        return def + 1;
+    }
+    """
+    And I turn on js2-mode and js2-refactor-mode
+    And I set logging to be before the use-site
+    When I go to the front of the word "arg"
+    And I press "C-c C-m lt"
+    Then I should see:
+    """
+    function abc() {
+        console.log("arg = ", arg);
+        callFunc(arg);
+        return def + 1;
+    }
+    """

--- a/features/js2r-log-this.feature
+++ b/features/js2r-log-this.feature
@@ -76,3 +76,31 @@ Feature: Log this
         return def + 1;
     }
     """
+
+  Scenario: Console.log in single-line function
+    Given I insert:
+    """
+    function a() { callFunc(xxx); return abc; }
+    """
+    And I turn on js2-mode and js2-refactor-mode
+    When I go to the front of the word "xxx"
+    And I press "C-c C-m lt"
+    Then I should see:
+    """
+    function a() { callFunc(xxx);
+                   console.log("xxx = ", xxx);return abc; }
+    """
+
+  Scenario: Console.log before return in single-line function
+    Given I insert:
+    """
+    function a() { callFunc(arg); return abc; }
+    """
+    And I turn on js2-mode and js2-refactor-mode
+    When I go to the front of the word "abc"
+    And I press "C-c C-m lt"
+    Then I should see:
+    """
+    function a() { callFunc(arg);
+                   console.log("abc = ", abc);return abc; }
+    """

--- a/features/step-definitions/js2-refactor-steps.el
+++ b/features/step-definitions/js2-refactor-steps.el
@@ -28,3 +28,7 @@
               (message "Can not go to character '%s' since it does not exist in the current buffer: %s"))
           (cl-assert search nil message word (espuds-buffer-contents))
           (if (string-equal "front" pos) (backward-word)))))
+
+(When "^I set logging to be before the use-site$"
+      (lambda ()
+        (setq-local js2r-log-before-point t)))

--- a/js2-refactor.el
+++ b/js2-refactor.el
@@ -175,6 +175,13 @@ This only affects arrow functions with one parameter."
 (defcustom js2r-prefer-let-over-var nil
   "When non-nil, js2r uses let constructs over var when performing refactorings.")
 
+(defcustom js2r-log-before-point  nil
+  "When non-nil, js2r inserts logging and debug statements before point.
+When nil, logging and debug statements are inserted after point,
+unless point is in a return statement."
+  :group 'js2-refactor
+  :type 'boolean)
+
 ;;; Keybindings ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun js2r--add-keybindings (key-fn)

--- a/js2r-conveniences.el
+++ b/js2r-conveniences.el
@@ -96,8 +96,7 @@ position where the log should be inserted."
   (if (js2-return-node-p parent-stmt)
       (save-excursion
         (goto-char (js2-node-abs-pos parent-stmt))
-        (beginning-of-line)
-        (forward-char -1)
+        (skip-chars-backward " \t\n\r") ; Can't use skip-syntax-backward since \n is end-comment
         (point))
     (js2-node-abs-end parent-stmt)))
 

--- a/js2r-conveniences.el
+++ b/js2r-conveniences.el
@@ -93,7 +93,7 @@ position where the log should be inserted."
 
 (defun js2r--find-suitable-log-position-around (parent-stmt)
   "Return the position close to PARENT-STMT where the log statement should be inserted."
-  (if (js2-return-node-p parent-stmt)
+  (if (or js2r-log-before-point (js2-return-node-p parent-stmt))
       (save-excursion
         (goto-char (js2-node-abs-pos parent-stmt))
         (skip-chars-backward " \t\n\r") ; Can't use skip-syntax-backward since \n is end-comment


### PR DESCRIPTION
Apologies that this PR contains two separate changes. They're split into one commit each:

1. **bugfix** Using `js2r-log-this` and similar in a single-line function on a return statement inserts the logging call in the wrong location:

```js
arr.forEach(function() { return this.|x })
// becomes
console.log("this.x = ", this.x);
arr.forEach(function() { return this.x })
```
 With this change, it becomes:
```js
arr.forEach(function() {
    console.log("this.x = ", this.x);return this.x })
```
  (Not perfect, but at least correct, and usually enough for a temporary logging call)

2. **enhancement** I usually need to include logging statement before the expression, since these are often `expect` calls. I added an option `js2r-always-log-before` to use the same placement as `return` logging calls. It defaults to `nil` for backward compatibility