### PR TITLE
More fixes for js2r--local-name-node-p

### DIFF
--- a/js2r-vars.el
+++ b/js2r-vars.el
@@ -46,10 +46,20 @@
 (defun js2r--local-name-node-p (node)
   (let ((parent (js2-node-parent node)))
     (and parent (js2-name-node-p node)
+         ;; is not foo in { foo: 1 }
          (not (and (js2-object-prop-node-p parent)
-                   (eq node (js2-object-prop-node-left parent))))
+                   (eq node (js2-object-prop-node-left parent))
+                   ;; could be { foo } though, in which case the node
+                   ;; is parent's both left and right.
+                   (not (eq node (js2-object-prop-node-right parent)))))
+         ;; is not foo in x.foo
          (not (and (js2-prop-get-node-p parent)
-                   (eq node (js2-prop-get-node-right parent)))))))
+                   (eq node (js2-prop-get-node-right parent))))
+         ;; is not foo in import { foo as bar } from ...
+         ;; could be bar, though.
+         (not (and (js2-export-binding-node-p parent)
+                   (eq node (js2-export-binding-node-extern-name parent))
+                   (not (eq node (js2-export-binding-node-local-name parent))))))))
 
 (defun js2r--name-node-defining-scope (name-node)
   (unless (js2r--local-name-node-p name-node)

--- a/test/js2r-local-name-node-at-point-test.el
+++ b/test/js2r-local-name-node-at-point-test.el
@@ -1,0 +1,40 @@
+(require 'js2-refactor)
+(require 'buttercup)
+
+(describe
+ "Find local name"
+
+ (it "finds the local name in import"
+     (with-js2-buffer "import { foo as bar } from 'lib'"
+       (search-backward "bar")
+       (expect (js2-name-node-name (js2r--local-name-node-at-point))
+               :to-equal "bar")))
+
+ (it "skips the remote name in named imports"
+     (with-js2-buffer "import { foo as bar } from 'lib'"
+       (search-backward "foo")
+       (expect (js2r--local-name-node-at-point)
+               :to-throw 'error)))
+
+ (it "exported name becomes local in import"
+     (with-js2-buffer "import { bar } from 'lib'"
+       (search-backward "bar")
+       (expect (js2-name-node-name (js2r--local-name-node-at-point))
+               :to-equal "bar")))
+
+ (it "the 'foo' in x.foo is not a local name"
+     (with-js2-buffer "x.foo"
+       (expect (js2r--local-name-node-at-point)
+               :to-throw 'error)))
+
+ (it "the 'foo' in { foo: 1 } is not a local name"
+     (with-js2-buffer "x = { foo: 1 }"
+       (search-backward "foo")
+       (expect (js2r--local-name-node-at-point)
+               :to-throw 'error)))
+
+ (it "the 'foo' in x = { foo } is a local name"
+     (with-js2-buffer "x = { foo }"
+       (search-backward "foo")
+       (expect (js2-name-node-name (js2r--local-name-node-at-point))
+               :to-equal "foo"))))


### PR DESCRIPTION
Fixes a few more cases where `js2r-rename-var` could fail to detect the symbol (see comments).  One of them depends on a [fix](https://github.com/mooz/js2-mode/pull/466) in js2-mode though (detecting the symbol in `{ name }`, without that fix `js2-node-at-point` will return a name node only if the cursor is on the `n`).