### PR TITLE
Add better support for `let` and `const`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ to pick and choose your own keybindings with a smattering of:
  * `ig` is `inject-global-in-iife`: Creates a shortcut for a marked global by injecting it in the wrapping immediately invoked function expression
  * `ag` is `add-to-globals-annotation`: Creates a `/*global */` annotation if it is missing, and adds the var at point to it.
  * `ev` is `extract-var`: Takes a marked expression and replaces it with a var.
+ * `el` is `extract-let`: Similar to `extract-var` but uses a `let`-statement.
+ * `ec` is `extract-const`: Similar to `extract-var` but uses a `const`-statement.
  * `iv` is `inline-var`: Replaces all instances of a variable with its initial value.
  * `rv` is `rename-var`: Renames the variable on point and all occurrences in its lexical scope.
  * `vt` is `var-to-this`: Changes local `var a` to be `this.a` instead.

--- a/features/js2r-extract-var.feature
+++ b/features/js2r-extract-var.feature
@@ -172,3 +172,33 @@ Feature: Extract var
     let three = 1 + 2;
     abc(three + 3, 4 + 5);
     """
+
+  Scenario: Use extract-let
+    When I insert "abc(1 + 2 + 3, 4 + 5);"
+    And I turn on js2-mode and js2-refactor-mode
+    And I go to the front of the word "1"
+    And I set the mark
+    And I go to the end of the word "2"
+    And I press "C-c C-m el"
+    And I press "C-u DEL"
+    And I type "three"
+    Then I should see:
+    """
+    let three = 1 + 2;
+    abc(three + 3, 4 + 5);
+    """
+
+  Scenario: Use extract-const
+    When I insert "abc(1 + 2 + 3, 4 + 5);"
+    And I turn on js2-mode and js2-refactor-mode
+    And I go to the front of the word "1"
+    And I set the mark
+    And I go to the end of the word "2"
+    And I press "C-c C-m ec"
+    And I press "C-u DEL"
+    And I type "three"
+    Then I should see:
+    """
+    const three = 1 + 2;
+    abc(three + 3, 4 + 5);
+    """

--- a/features/js2r-split-var-declaration.feature
+++ b/features/js2r-split-var-declaration.feature
@@ -12,6 +12,30 @@ Feature: Split var declaration
     """
     And I should not see "var a, b, c;"
 
+  Scenario: Split simple let
+    When I insert "let a, b, c;"
+    And I turn on js2-mode and js2-refactor-mode
+    And I press "C-c C-m sv"
+    Then I should see:
+    """
+    let a;
+    let b;
+    let c;
+    """
+    And I should not see "let a, b, c;"
+
+  Scenario: Split simple const
+    When I insert "const a, b, c;"
+    And I turn on js2-mode and js2-refactor-mode
+    And I press "C-c C-m sv"
+    Then I should see:
+    """
+    const a;
+    const b;
+    const c;
+    """
+    And I should not see "const a, b, c;"
+
   Scenario: Split vars with values
     When I insert "var a = 1, b = '2', c = { d: 3 };"
     And I turn on js2-mode and js2-refactor-mode

--- a/js2-refactor.el
+++ b/js2-refactor.el
@@ -63,6 +63,8 @@
 ;;  * `ig` is `inject-global-in-iife`: Creates a shortcut for a marked global by injecting it in the wrapping immediately invoked function expression
 ;;  * `ag` is `add-to-globals-annotation`: Creates a `/*global */` annotation if it is missing, and adds the var at point to it.
 ;;  * `ev` is `extract-var`: Takes a marked expression and replaces it with a var.
+;;  * `el` is `extract-var`: Takes a marked expression and replaces it with a let.
+;;  * `ec` is `extract-var`: Takes a marked expression and replaces it with a const.
 ;;  * `iv` is `inline-var`: Replaces all instances of a variable with its initial value.
 ;;  * `rv` is `rename-var`: Renames the variable on point and all occurrences in its lexical scope.
 ;;  * `vt` is `var-to-this`: Changes local `var a` to be `this.a` instead.
@@ -182,6 +184,8 @@ This only affects arrow functions with one parameter."
   (define-key js2-refactor-mode-map (funcall key-fn "wi") #'js2r-wrap-buffer-in-iife)
   (define-key js2-refactor-mode-map (funcall key-fn "ig") #'js2r-inject-global-in-iife)
   (define-key js2-refactor-mode-map (funcall key-fn "ev") #'js2r-extract-var)
+  (define-key js2-refactor-mode-map (funcall key-fn "el") #'js2r-extract-let)
+  (define-key js2-refactor-mode-map (funcall key-fn "ec") #'js2r-extract-const)
   (define-key js2-refactor-mode-map (funcall key-fn "iv") #'js2r-inline-var)
   (define-key js2-refactor-mode-map (funcall key-fn "rv") #'js2r-rename-var)
   (define-key js2-refactor-mode-map (funcall key-fn "vt") #'js2r-var-to-this)


### PR DESCRIPTION
Depending on what I'm writing code for, I use both `var`, `let` and `const`-statements a lot. This PR adds `js2r-extract-let` (`el`) and `js2r-extract-const` (`ec`) functions that work the same way as `js2r-extract-var`.

Also, the `js2r-split-var-declaration` function is changed to support `let` and `const` statements.