### PR TITLE
Add toggle-function-async refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ to pick and choose your own keybindings with a smattering of:
  * `em` is `extract-method`: Extracts the marked expressions out into a new named method in an object literal.
  * `tf` is `toggle-function-expression-and-declaration`: Toggle between function name() {} and var name = function ();
  * `ta` is `toggle-arrow-function-and-expression`: Toggle between function expression to arrow function.
+ * `ts` is `toggle-function-async`: Toggle between an async and a regular function.
  * `ip` is `introduce-parameter`: Changes the marked expression to a parameter in a local function.
  * `lp` is `localize-parameter`: Changes a parameter to a local var in a local function.
  * `wi` is `wrap-buffer-in-iife`: Wraps the entire buffer in an immediately invoked function expression

--- a/features/js2r-toggle-functions.feature
+++ b/features/js2r-toggle-functions.feature
@@ -88,3 +88,42 @@
     """
     emitter.on('event', evt => { return console.log(evt); });
     """
+
+  Scenario: Toggling async function
+    When I insert "p.then(async function(ret) { return process(ret, arg); });"
+    And I turn on js2-mode and js2-refactor-mode
+    And I go to the front of the word "process"
+    And I press "C-c C-m ts"
+    Then I should see:
+    """
+    p.then(function(ret) { return process(ret, arg); });
+    """
+  Scenario: Toggling non-async function
+    When I insert "p.then(function(ret) { return process(ret, arg); });"
+    And I turn on js2-mode and js2-refactor-mode
+    And I go to the front of the word "process"
+    And I press "C-c C-m ts"
+    Then I should see:
+    """
+    p.then(async function(ret) { return process(ret, arg); });
+    """
+
+  Scenario: Toggling async arrow function
+    When I insert "p.then(async (ret) => process(ret, arg));"
+    And I turn on js2-mode and js2-refactor-mode
+    And I go to the front of the word "process"
+    And I press "C-c C-m ts"
+    Then I should see:
+    """
+    p.then((ret) => process(ret, arg));
+    """
+
+  Scenario: Toggling non-async arrow function
+    When I insert "p.then(ret => process(ret, arg));"
+    And I turn on js2-mode and js2-refactor-mode
+    And I go to the front of the word "process"
+    And I press "C-c C-m ts"
+    Then I should see:
+    """
+    p.then(async ret => process(ret, arg));
+    """

--- a/js2-refactor.el
+++ b/js2-refactor.el
@@ -57,6 +57,7 @@
 ;;  * `em` is `extract-method`: Extracts the marked expressions out into a new named method in an object literal.
 ;;  * `tf` is `toggle-function-expression-and-declaration`: Toggle between function name() {} and var name = function ();
 ;;  * `ta` is `toggle-arrow-function-and-expression`: Toggle between function expression to arrow function.
+;;  * `ts` is `toggle-function-async`: Toggle between an async and a regular function.
 ;;  * `ip` is `introduce-parameter`: Changes the marked expression to a parameter in a local function.
 ;;  * `lp` is `localize-parameter`: Changes a parameter to a local var in a local function.
 ;;  * `wi` is `wrap-buffer-in-iife`: Wraps the entire buffer in an immediately invoked function expression
@@ -205,6 +206,7 @@ unless point is in a return statement."
   (define-key js2-refactor-mode-map (funcall key-fn "lp") #'js2r-localize-parameter)
   (define-key js2-refactor-mode-map (funcall key-fn "tf") #'js2r-toggle-function-expression-and-declaration)
   (define-key js2-refactor-mode-map (funcall key-fn "ta") #'js2r-toggle-arrow-function-and-expression)
+  (define-key js2-refactor-mode-map (funcall key-fn "ts") #'js2r-toggle-function-async)
   (define-key js2-refactor-mode-map (funcall key-fn "ao") #'js2r-arguments-to-object)
   (define-key js2-refactor-mode-map (funcall key-fn "uw") #'js2r-unwrap)
   (define-key js2-refactor-mode-map (funcall key-fn "wl") #'js2r-wrap-in-for-loop)

--- a/js2r-functions.el
+++ b/js2r-functions.el
@@ -520,5 +520,14 @@
     (forward-list)
     (insert ";")))
 
+(defun js2r-toggle-function-async ()
+  "Toggle the innermost function from sync to async."
+  (interactive)
+  (save-excursion
+    (js2r--find-closest-function)
+    (if (looking-back "async[[:space:]\n]+")
+        (delete-region (match-beginning 0) (match-end 0))
+      (insert "async "))))
+
 (provide 'js2r-functions)
 ;;; js2-functions.el ends here


### PR DESCRIPTION
I use this a lot when I'm refactoring a function to be async instead of using promise chains. Also useful when the async logic is extracted out of a function which can simply return a promise.

Since `ta` was already taken for toggle arrow, I used `ts` for the mnemonic.