### PR TITLE
Add string-to-template refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ to pick and choose your own keybindings with a smattering of:
  * `3i` is `ternary-to-if`: Converts ternary operator to if-statement.
  * `sv` is `split-var-declaration`: Splits a `var` with multiple vars declared, into several `var` statements.
  * `ss` is `split-string`: Splits a `string`.
+ * `st` is `string-to-template`: Converts a `string` into a template string.
  * `uw` is `unwrap`: Replaces the parent statement with the selected region.
  * `lt` is `log-this`: Adds a console.log() statement for what is at point (or region). With a prefix argument, use JSON pretty-printing.
  * `dt` is `debug-this`: Adds a debug() statement for what is at point (or region).

--- a/features/js2r-string-to-template.feature
+++ b/features/js2r-string-to-template.feature
@@ -1,0 +1,43 @@
+Feature: String to template
+
+  Scenario: Convert single-quote string to template
+    When I insert "const c = 'this is a string'"
+    And I turn on js2-mode and js2-refactor-mode
+    And I go to the front of the word "string"
+    And I press "C-c C-m st"
+    Then I should see "const c = `this is a string`"
+
+  Scenario: Convert double-quote string to template
+    When I insert "const c = "this is a string""
+    And I turn on js2-mode and js2-refactor-mode
+    And I go to the front of the word "string"
+    And I press "C-c C-m st"
+    Then I should see "const c = `this is a string`"
+
+  Scenario: Do nothing on template strings
+    When I insert "const c = `this is a string`"
+    And I turn on js2-mode and js2-refactor-mode
+    And I go to the front of the word "string"
+    And I press "C-c C-m st"
+    Then I should see "const c = `this is a string`"
+
+  Scenario: Do nothing on template strings with interpolation
+    When I insert "const c = `this is a ${xyz} string`"
+    And I turn on js2-mode and js2-refactor-mode
+    And I go to the front of the word "string"
+    And I press "C-c C-m st"
+    Then I should see "const c = `this is a ${xyz} string`"
+
+  Scenario: Escape backticks inside strings
+    When I insert "const c = 'this `is a `string'"
+    And I turn on js2-mode and js2-refactor-mode
+    And I go to the front of the word "string"
+    And I press "C-c C-m st"
+    Then I should see "const c = `this \`is a \`string`"
+
+  Scenario: Handles the empty string
+    When I insert "const c = ''"
+    And I turn on js2-mode and js2-refactor-mode
+    And I go to character "'"
+    And I press "C-c C-m st"
+    Then I should see "const c = ``"

--- a/js2-refactor.el
+++ b/js2-refactor.el
@@ -73,6 +73,7 @@
 ;;  * `3i` is `ternary-to-if`: Converts ternary operator to if-statement.
 ;;  * `sv` is `split-var-declaration`: Splits a `var` with multiple vars declared, into several `var` statements.
 ;;  * `ss` is `split-string`: Splits a `string`.
+;;  * `st` is `string-to-template`: Converts a `string` into a template string.
 ;;  * `uw` is `unwrap`: Replaces the parent statement with the selected region.
 ;;  * `lt` is `log-this`: Adds a console.log() statement for what is at point (or region).  With a prefix argument, use JSON pretty-printing.
 ;;  * `dt` is `debug-this`: Adds a debug() statement for what is at point (or region).
@@ -200,6 +201,7 @@ unless point is in a return statement."
   (define-key js2-refactor-mode-map (funcall key-fn "ag") #'js2r-add-to-globals-annotation)
   (define-key js2-refactor-mode-map (funcall key-fn "sv") #'js2r-split-var-declaration)
   (define-key js2-refactor-mode-map (funcall key-fn "ss") #'js2r-split-string)
+  (define-key js2-refactor-mode-map (funcall key-fn "st") #'js2r-string-to-template)
   (define-key js2-refactor-mode-map (funcall key-fn "ef") #'js2r-extract-function)
   (define-key js2-refactor-mode-map (funcall key-fn "em") #'js2r-extract-method)
   (define-key js2-refactor-mode-map (funcall key-fn "ip") #'js2r-introduce-parameter)

--- a/js2r-conveniences.el
+++ b/js2r-conveniences.el
@@ -117,16 +117,15 @@ position where the log should be inserted."
 (defun js2r-string-to-template ()
   "Convert the string at point into a template string."
   (interactive)
-  (when (memq (js2r--point-inside-string-p) '(?\" ?\'))
-    (let* ((syntax (syntax-ppss))
-           (start (nth 8 syntax))
-           end
-           (forward-sexp-function nil))
-      (save-excursion
-        (goto-char start) (forward-sexp) (delete-char -1) (insert "`")
-        (setq end (point))
-        (goto-char start) (delete-char 1) (insert "`")
-        (perform-replace "`" "\\`" nil nil nil nil nil (1+ start) (1- end))))))
+  (let ((node (js2-node-at-point)))
+    (when (js2-string-node-p node)
+      (let* ((start (js2-node-abs-pos node))
+             (end (+ start (js2-node-len node))))
+        (when (memq (char-after start) '(?' ?\"))
+          (save-excursion
+            (goto-char end) (delete-char -1) (insert "`")
+            (goto-char start) (delete-char 1) (insert "`")
+            (perform-replace "`" "\\`" nil nil nil nil nil (1+ start) (1- end))))))))
 
 (defun js2r--string-delimiter (node)
   "Return the delimiter character of the string node NODE.

--- a/js2r-conveniences.el
+++ b/js2r-conveniences.el
@@ -114,6 +114,20 @@ position where the log should be inserted."
            (delete-char 5)
          (insert (format "%s + %s" delimiter delimiter)))))))
 
+(defun js2r-string-to-template ()
+  "Convert the string at point into a template string."
+  (interactive)
+  (when (memq (js2r--point-inside-string-p) '(?\" ?\'))
+    (let* ((syntax (syntax-ppss))
+           (start (nth 8 syntax))
+           end
+           (forward-sexp-function nil))
+      (save-excursion
+        (goto-char start) (forward-sexp) (delete-char -1) (insert "`")
+        (setq end (point))
+        (goto-char start) (delete-char 1) (insert "`")
+        (perform-replace "`" "\\`" nil nil nil nil nil (1+ start) (1- end))))))
+
 (defun js2r--string-delimiter (node)
   "Return the delimiter character of the string node NODE.
 It can be a single or double quote."


### PR DESCRIPTION
This is for when you need to add an interpolation to an existing string, to easily change the delimiters to "`"